### PR TITLE
Fixed the build process for the IdP and SP classes.

### DIFF
--- a/lib/saml2/identity_provider.rb
+++ b/lib/saml2/identity_provider.rb
@@ -54,7 +54,7 @@ module SAML2
       builder['md'].IDPSSODescriptor do |idp_sso_descriptor|
         super(idp_sso_descriptor)
 
-        idp_sso_descriptor['WantAuthnRequestsSigned'] = want_authn_requests_signed? unless want_authn_requests_signed?.nil?
+        idp_sso_descriptor.parent['WantAuthnRequestsSigned'] = want_authn_requests_signed? unless want_authn_requests_signed?.nil?
 
         single_sign_on_services.each do |sso|
           sso.build(idp_sso_descriptor, 'SingleSignOnService')

--- a/lib/saml2/service_provider.rb
+++ b/lib/saml2/service_provider.rb
@@ -61,8 +61,8 @@ module SAML2
       builder['md'].SPSSODescriptor do |sp_sso_descriptor|
         super(sp_sso_descriptor)
 
-        sp_sso_descriptor['AuthnRequestsSigned'] = authn_requests_signed? unless authn_requests_signed?.nil?
-        sp_sso_descriptor['WantAssertionsSigned'] = want_assertions_signed? unless authn_requests_signed?.nil?
+        sp_sso_descriptor.parent['AuthnRequestsSigned'] = authn_requests_signed? unless authn_requests_signed?.nil?
+        sp_sso_descriptor.parent['WantAssertionsSigned'] = want_assertions_signed? unless authn_requests_signed?.nil?
 
         assertion_consumer_services.each do |acs|
           acs.build(sp_sso_descriptor, 'AssertionConsumerService')


### PR DESCRIPTION
Noticed that when I was setting the arguments for the IdP or SP classes it was creating nodes rather than setting the arguments and we needed to call ".parent" on the node. Since the code I did yesterday was inspired by the IdP class it was faulty.