### PR TITLE
Fix handling of service provider attributes when parsing an XML file

### DIFF
--- a/lib/saml2/service_provider.rb
+++ b/lib/saml2/service_provider.rb
@@ -20,6 +20,8 @@ module SAML2
     # (see Base#from_xml)
     def from_xml(node)
       super
+      remove_instance_variable(:@authn_requests_signed)
+      remove_instance_variable(:@want_assertions_signed)
       @assertion_consumer_services = nil
       @attribute_consuming_services = nil
     end

--- a/spec/fixtures/identity_provider.xml
+++ b/spec/fixtures/identity_provider.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://sso.school.edu/idp/shibboleth">
-  <IDPSSODescriptor protocolSupportEnumeration="urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:1.1:protocol urn:oasis:names:tc:SAML:2.0:protocol">
+  <IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:1.1:protocol urn:oasis:names:tc:SAML:2.0:protocol">
     <KeyDescriptor use="signing">
       <ds:KeyInfo>
         <ds:X509Data>

--- a/spec/fixtures/service_provider.xml
+++ b/spec/fixtures/service_provider.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://siteadmin.instructure.com/saml2" ID="unique">
-  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+  <SPSSODescriptor AuthnRequestsSigned="true" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
 
     <KeyDescriptor use="encryption">
       <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">

--- a/spec/lib/identity_provider_spec.rb
+++ b/spec/lib/identity_provider_spec.rb
@@ -32,6 +32,10 @@ module SAML2
       it "should find the signing certificate" do
         expect(idp.keys.first.x509).to match(/MIIE8TCCA9mgAwIBAgIJAITusxON60cKMA0GCSqGSIb3DQEBBQUAMIGrMQswCQYD/)
       end
+
+      it "loads identity provider attributes" do
+        expect(idp.want_authn_requests_signed?).to be_truthy
+      end
     end
   end
 end

--- a/spec/lib/service_provider_spec.rb
+++ b/spec/lib/service_provider_spec.rb
@@ -64,6 +64,11 @@ module SAML2
         expect(sp.keys.first.encryption_methods.first.algorithm).to eq KeyDescriptor::EncryptionMethod::Algorithm::AES128_CBC
         expect(sp.keys.first.encryption_methods.first.key_size).to eq 128
       end
+
+      it "loads service provider attributes" do
+        expect(sp.authn_requests_signed?).to be_truthy
+        expect(sp.want_assertions_signed?).to be_truthy
+      end
     end
   end
 end


### PR DESCRIPTION
When #5 added service provider attributes, it didn't update `ServiceProvider#from_xml` method accordingly.

This PR fixes the issue in the same way `IdentityProvider#from_xml` handles such cases.