### PR TITLE
Update nokogiri version range in saml2.gemspec

### DIFF
--- a/saml2.gemspec
+++ b/saml2.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   # Very specifically at least 1.5.8 - they fixed a bug with namespaces
   # on root elements with XML::Builder in that release
-  s.add_dependency 'nokogiri', ">= 1.5.8", "< 1.11"
+  s.add_dependency 'nokogiri', ">= 1.5.8", "<= 1.11"
   s.add_dependency 'nokogiri-xmlsec-instructure', "~> 0.9", ">= 0.9.5"
   s.add_dependency 'activesupport', ">= 3.2", "< 6.2"
 


### PR DESCRIPTION
nokogiri fixes [CVE-2020-26247](https://github.com/advisories/GHSA-vr8q-g5c7-m54m)
in version 1.11.0 (releasing shortly).

It may also be worthwhile to check the other changes to ensure compatibility.
https://github.com/sparklemotion/nokogiri/releases/tag/v1.11.0

Testing:
- Downloaded repo
- Switched to using nokogiri 1.11.0
- Ran `bundle install`
- Ran `bundle exec rspec spec/` and saw no failures


This may not be sufficient to fully test using nokogiri on version 1.11.0, please
review the changes and perform additional steps as necessary