### PR TITLE
Allow any Nokogiri 1.12 version

### DIFF
--- a/saml2.gemspec
+++ b/saml2.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   # Very specifically at least 1.5.8 - they fixed a bug with namespaces
   # on root elements with XML::Builder in that release
-  s.add_dependency 'nokogiri', ">= 1.5.8", "< 1.12"
+  s.add_dependency 'nokogiri', ">= 1.5.8", "< 1.13"
   s.add_dependency 'nokogiri-xmlsec-instructure', "~> 0.9", ">= 0.9.5"
   s.add_dependency 'activesupport', ">= 3.2", "< 6.2"
 


### PR DESCRIPTION
This opens saml2 up to support more recent Nokogiri versions, such as https://rubygems.org/gems/nokogiri/versions/1.12.5

All tests pass with this new version of Nokogiri.